### PR TITLE
Index out of bounds exception

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/Printer.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT Printing/win32/org/eclipse/swt/printing/Printer.java
@@ -137,7 +137,7 @@ public static PrinterData getDefaultPrinterData() {
 	int n = OS.GetProfileString(appName, keyName, nullBuf, buf, length);
 	if (n == 0) return null;
 	int commaIndex = 0;
-	while(buf.tcharAt(commaIndex) != ',' && commaIndex < length) commaIndex++;
+	while(commaIndex < length && buf.tcharAt(commaIndex) != ',') commaIndex++;
 	if (commaIndex < length) {
 		deviceName = buf.toString(0, commaIndex);
 	}
@@ -145,7 +145,7 @@ public static PrinterData getDefaultPrinterData() {
 	String driver = ""; //$NON-NLS-1$
 	if (OS.GetProfileString(profile, new TCHAR(0, deviceName, true), nullBuf, buf, length) > 0) {
 		commaIndex = 0;
-		while (buf.tcharAt(commaIndex) != ',' && commaIndex < length) commaIndex++;
+		while (commaIndex < length && buf.tcharAt(commaIndex) != ',') commaIndex++;
 		if (commaIndex < length) {
 			driver = buf.toString(0, commaIndex);
 		}


### PR DESCRIPTION
when there is no coma (',') in the buffer, commaIndex variable will have the value 1024 and
buf.tcharAt(commaIndex) will cause index out of bounds exception on line 140