### PR TITLE
Updated the mailing list info

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Contact:
 
 Contact the project developers via the project's "dev" list.
 
-- <https://dev.eclipse.org/mailman/listinfo/platform-swt-dev>
+- <https://accounts.eclipse.org/mailing-list/platform-dev>
 
 Search for bugs:
 ----------------


### PR DESCRIPTION
As per bug [541508](https://bugs.eclipse.org/bugs/show_bug.cgi?id=541508) The platform-swt-dev mailing list is closed, and  platform-dev mailing list is to be used.
Signed-off-by: Himanshu Balasamanta <himanshubb.eee18@itbhu.ac.in>